### PR TITLE
macos support & fix invoke-ccmsoftwareupdate using pssession

### DIFF
--- a/Source/Public/Get-CCMApplication.ps1
+++ b/Source/Public/Get-CCMApplication.ps1
@@ -88,7 +88,7 @@ function Get-CCMApplication {
                         [string]::Format('$AppFound.ID -eq "{0}"', [string]::Join('" -or $AppFound.ID -eq "', $ApplicationID))
                     }
                 }
-                [ciminstance[]]$applications = switch ($Computer -eq $env:ComputerName) {
+                [array]$applications = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getapplicationsplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMCacheContent.ps1
+++ b/Source/Public/Get-CCMCacheContent.ps1
@@ -37,7 +37,7 @@ function Get-CCMCacheContent {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CacheContent = switch ($Computer -eq $env:ComputerName) {
+                [array]$CacheContent = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getCacheContentSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMCacheInfo.ps1
+++ b/Source/Public/Get-CCMCacheInfo.ps1
@@ -37,7 +37,7 @@ function Get-CCMCacheInfo {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CimResult = switch ($Computer -eq $env:ComputerName) {
+                [array]$CimResult = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getCacheInfoSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMClientVersion.ps1
+++ b/Source/Public/Get-CCMClientVersion.ps1
@@ -36,7 +36,7 @@ function Get-CCMClientVersion {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$Currentversion = switch ($Computer -eq $env:ComputerName) {
+                [array]$Currentversion = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getClientVersionSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMCurrentManagementPoint.ps1
+++ b/Source/Public/Get-CCMCurrentManagementPoint.ps1
@@ -37,7 +37,7 @@ function Get-CCMCurrentManagementPoint {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CurrentMP = switch ($Computer -eq $env:ComputerName) {
+                [array]$CurrentMP = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getCurrentMPSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMCurrentSoftwareUpdatePoint.ps1
+++ b/Source/Public/Get-CCMCurrentSoftwareUpdatePoint.ps1
@@ -37,7 +37,7 @@ function Get-CCMCurrentSoftwareUpdatePoint {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CurrentSUP = switch ($Computer -eq $env:ComputerName) {
+                [array]$CurrentSUP = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @CurrentSUPSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMExecStartupTime.ps1
+++ b/Source/Public/Get-CCMExecStartupTime.ps1
@@ -36,7 +36,7 @@ function Get-CCMExecStartupTime {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CCMExecService = switch ($Computer -eq $env:ComputerName) {
+                [array]$CCMExecService = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getCCMExecServiceSplat @connectionSplat
                     }
@@ -47,7 +47,7 @@ function Get-CCMExecStartupTime {
                 if ($CCMExecService -is [Object] -and $CCMExecService.Count -gt 0) {
                     foreach ($Service in $CCMExecService) {
                         $getCCMExecProcessSplat['Query'] = [string]::Format("Select CreationDate from Win32_Process WHERE ProcessID = '{0}'", $Service.ProcessID)
-                        [ciminstance[]]$CCMExecProcess = switch ($Computer -eq $env:ComputerName) {
+                        [array]$CCMExecProcess = switch ($Computer -eq $env:ComputerName) {
                             $true {
                                 Get-CimInstance @getCCMExecProcessSplat @connectionSplat
                             }

--- a/Source/Public/Get-CCMGUID.ps1
+++ b/Source/Public/Get-CCMGUID.ps1
@@ -37,7 +37,7 @@ function Get-CCMGUID {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CurrentGUID = switch ($Computer -eq $env:ComputerName) {
+                [array]$CurrentGUID = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getGUIDSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMLastHardwareInventory.ps1
+++ b/Source/Public/Get-CCMLastHardwareInventory.ps1
@@ -38,7 +38,7 @@ function Get-CCMLastHardwareInventory {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$LastHinv = switch ($Computer -eq $env:ComputerName) {
+                [array]$LastHinv = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getLastHinvSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMLastHeartbeat.ps1
+++ b/Source/Public/Get-CCMLastHeartbeat.ps1
@@ -38,7 +38,7 @@ function Get-CCMLastHeartbeat {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$LastDDR = switch ($Computer -eq $env:ComputerName) {
+                [array]$LastDDR = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getLastDDRSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMLastScheduleTrigger.ps1
+++ b/Source/Public/Get-CCMLastScheduleTrigger.ps1
@@ -177,7 +177,7 @@ function Get-CCMLastScheduleTrigger {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$ScheduleHistory = switch ($Computer -eq $env:ComputerName) {
+                [array]$ScheduleHistory = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getSchedHistSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMLastSoftwareInventory.ps1
+++ b/Source/Public/Get-CCMLastSoftwareInventory.ps1
@@ -38,7 +38,7 @@ function Get-CCMLastSoftwareInventory {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$LastSINV = switch ($Computer -eq $env:ComputerName) {
+                [array]$LastSINV = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getLastSINVSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMLoggingConfiguration.ps1
+++ b/Source/Public/Get-CCMLoggingConfiguration.ps1
@@ -43,7 +43,7 @@ function Get-CCMLoggingConfiguration {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$CimResult = switch ($Computer -eq $env:ComputerName) {
+                [array]$CimResult = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getLogInfoSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMMaintenanceWindow.ps1
+++ b/Source/Public/Get-CCMMaintenanceWindow.ps1
@@ -74,7 +74,7 @@ function Get-CCMMaintenanceWindow {
                 }
                 $Result['TimeZone'] = $TZ.Caption
 
-                [ciminstance[]]$ServiceWindows = switch ($Computer -eq $env:ComputerName) {
+                [array]$ServiceWindows = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getMaintenanceWindowSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMPackage.ps1
+++ b/Source/Public/Get-CCMPackage.ps1
@@ -63,7 +63,7 @@ function Get-CCMPackage {
                 }
                 $getPackageSplat['Query'] = [string]::Format('SELECT * FROM CCM_SoftwareDistribution{0}', $Filter)
 
-                [ciminstance[]]$Packages = switch ($Computer -eq $env:ComputerName) {
+                [array]$Packages = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getPackageSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMPrimaryUser.ps1
+++ b/Source/Public/Get-CCMPrimaryUser.ps1
@@ -39,7 +39,7 @@ function Get-CCMPrimaryUser {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$PrimaryUsers = switch ($Computer -eq $env:ComputerName) {
+                [array]$PrimaryUsers = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getPrimaryUserSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMServiceWindow.ps1
+++ b/Source/Public/Get-CCMServiceWindow.ps1
@@ -61,7 +61,7 @@ function Get-CCMServiceWindow {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$ServiceWindows = switch ($Computer -eq $env:ComputerName) {
+                [array]$ServiceWindows = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getServiceWindowSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMSoftwareUpdate.ps1
+++ b/Source/Public/Get-CCMSoftwareUpdate.ps1
@@ -89,7 +89,7 @@ function Get-CCMSoftwareUpdate {
             $Result['ComputerName'] = $Computer
 
             try {
-                [ciminstance[]]$MissingUpdates = switch ($Computer -eq $env:ComputerName) {
+                [array]$MissingUpdates = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getUpdateSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMSoftwareUpdateGroup.ps1
+++ b/Source/Public/Get-CCMSoftwareUpdateGroup.ps1
@@ -69,7 +69,7 @@ function Get-CCMSoftwareUpdateGroup {
                 }
                 $getSUGSplat['Query'] = [string]::Format('SELECT * FROM CCM_UpdateCIAssignment{0}', $Filter)
 
-                [ciminstance[]]$DeployedSUG = switch ($Computer -eq $env:ComputerName) {
+                [array]$DeployedSUG = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getSUGSplat @connectionSplat
                     }

--- a/Source/Public/Get-CCMSoftwareUpdateSettings.ps1
+++ b/Source/Public/Get-CCMSoftwareUpdateSettings.ps1
@@ -36,7 +36,7 @@ function Get-CCMSoftwareUpdateSettings {
             $Result = [ordered]@{ }
             $Result['ComputerName'] = $Computer
 
-            [ciminstance[]]$Settings = switch ($Computer -eq $env:ComputerName) {
+            [array]$Settings = switch ($Computer -eq $env:ComputerName) {
                 $true {
                     Get-CimInstance @getSoftwareUpdateSettingsSplat @connectionSplat
                 }

--- a/Source/Public/Get-CCMTaskSequence.ps1
+++ b/Source/Public/Get-CCMTaskSequence.ps1
@@ -57,7 +57,7 @@ function Get-CCMTaskSequence {
                 }
                 $getPackageSplat['Query'] = [string]::Format('SELECT * FROM CCM_TaskSequence{0}', $Filter)
 
-                [ciminstance[]]$Packages = switch ($Computer -eq $env:ComputerName) {
+                [array]$Packages = switch ($Computer -eq $env:ComputerName) {
                     $true {
                         Get-CimInstance @getPackageSplat @connectionSplat
                     }

--- a/Source/Public/Invoke-CCMPackage.ps1
+++ b/Source/Public/Invoke-CCMPackage.ps1
@@ -88,7 +88,7 @@ function Invoke-CCMPackage {
                     }
                     $getPackageSplat['Query'] = [string]::Format('SELECT * FROM CCM_SoftwareDistribution{0}', $Filter)
 
-                    [ciminstance[]]$Packages = switch ($Computer -eq $env:ComputerName) {
+                    [array]$Packages = switch ($Computer -eq $env:ComputerName) {
                         $true {
                             Get-CimInstance @getPackageSplat @connectionSplat
                         }

--- a/Source/Public/Invoke-CCMSoftwareUpdate.ps1
+++ b/Source/Public/Invoke-CCMSoftwareUpdate.ps1
@@ -70,24 +70,29 @@ function Invoke-CCMSoftwareUpdate {
                                 $ArticleID = $MissingUpdates.ArticleID
                             }
                         }
-                        $invokeCIMMethodSplat['Arguments'] = @{
-                            CCMUpdates = [ciminstance[]]$MissingUpdates
-                        }
-
                         $Invocation = switch -regex ($ConnectionInfo.ConnectionType) {
                             '^ComputerName$|^CimSession$' {
+                                $invokeCIMMethodSplat['Arguments'] = @{
+                                    CCMUpdates = [ciminstance[]]$MissingUpdates
+                                }
                                 Invoke-CimMethod @invokeCIMMethodSplat @connectionSplat -ErrorAction Stop
                             }
-                        # TODO - Fix PSSession support. Currently does not work.
                             'PSSession' {
+                            # Pass list of missing updates to the target machine as a parameter,
+                            # then do any casting etc required and build icim's arguments there
+                            # The Out-Null in the script block is required to avoid 'Could not infer CimType from the provided .NET object' errors, though not sure why it prevents them.
                                 $invokeUpdatesSplat = @{
                                     ScriptBlock  = {
                                         param (
-                                            $invokeCIMMethodSplat
+                                            $invokeCIMMethodSplat,
+                                            $toInstall
                                         )
-                                        Invoke-CimMethod @invokeCIMMethodSplat
+                                        $toInstall|Out-Null
+                                        Invoke-CimMethod @invokeCIMMethodSplat -Arguments @{
+                                            CCMUpdates = [ciminstance[]]$toInstall
+                                        }
                                     }
-                                    ArgumentList = $invokeCIMMethodSplat
+                                    ArgumentList = $invokeCIMMethodSplat, $MissingUpdates
                                 }
                                 Invoke-Command @invokeUpdatesSplat @connectionSplat
                             }

--- a/Source/Public/Invoke-CCMSoftwareUpdate.ps1
+++ b/Source/Public/Invoke-CCMSoftwareUpdate.ps1
@@ -55,7 +55,7 @@ function Invoke-CCMSoftwareUpdate {
                         }
                     }
 
-                    [ciminstance[]]$MissingUpdates = switch ($Computer -eq $env:ComputerName) {
+                    [array]$MissingUpdates = switch ($Computer -eq $env:ComputerName) {
                         $true {
                             Get-CimInstance @getUpdateSplat @connectionSplat
                         }
@@ -64,7 +64,7 @@ function Invoke-CCMSoftwareUpdate {
                         }
                     }
 
-                    if ($MissingUpdates -is [ciminstance[]]) {
+                    if ($MissingUpdates -is [array]) {
                         switch ($PSBoundParameters.ContainsKey('ArticleID')) {
                             $false {
                                 $ArticleID = $MissingUpdates.ArticleID

--- a/Source/Public/Invoke-CCMTaskSequence.ps1
+++ b/Source/Public/Invoke-CCMTaskSequence.ps1
@@ -82,7 +82,7 @@ function Invoke-CCMTaskSequence {
                     }
                     $getTaskSequenceSplat['Query'] = [string]::Format('SELECT * FROM CCM_TaskSequence{0}', $Filter)
 
-                    [ciminstance[]]$TaskSequences = switch ($Computer -eq $env:ComputerName) {
+                    [array]$TaskSequences = switch ($Computer -eq $env:ComputerName) {
                         $true {
                             Get-CimInstance @getTaskSequenceSplat @connectionSplat
                         }


### PR DESCRIPTION
- Remove the casts of `Get-CimInstance` output to `[CimInstance[]]` to allow the module to be used on non-Windows platforms that don't have `[CimInstance]`. Tested on macOS and Windows, but Linux should work too.
- Fix using `Invoke-CCMSoftwareUpdate` using a PSSession. PSSessions have to be used from non-Windows platforms, so this contributed to the above.

`CimInstance` and cim cmdlets are Windows-only, so anything using them elsewhere errors. Fortunately, most of the usage here isn't strictly required- most of the usage is casting the output from `Get-CimInstance` to `[CimInstance[]]`, which is not usually required. 

- On Windows, `gcim` or `icm {gcim}` return an `Object[]` containing `CimInstance`s, so the casting is ensuring the result is an array, and changing the containing array's type.
- On macOS (and presumably Linux) `icm {gcim}` returns an `Object[]` containing `PSObject`s due to the lack of `CimInstance`
- Casts were change to `[array]` rather than `[object[]]` to be clearer that they're there to ensure the result is an array, rather than objects.

The only situation (I think) where a `[CimInstance[]]` specifically is required is `CCM_SoftwareUpdatesManager`'s `InstallUpdates()` method, which is solved by doing the cast to `[CimInstance[]]` on the target machine via `Invoke-Command`, which will always have the type available if `Invoke-CimMethod` is going to work.